### PR TITLE
Fixed CSS issues arising in previous navbar styling

### DIFF
--- a/Frontend/Components/Navbar/Navbar.css
+++ b/Frontend/Components/Navbar/Navbar.css
@@ -1,5 +1,5 @@
 header {
-    width: 100vw;
+    width: 100%;
     height: 15vh;
     background-color: rgb(44, 62, 80);
     margin: 0;

--- a/Frontend/Components/Navbar/Navbar.css
+++ b/Frontend/Components/Navbar/Navbar.css
@@ -25,12 +25,14 @@ h1 {
     display: flex;
     flex-grow: 1;
     align-items: center;
+    justify-content: center;
     text-decoration: none;
 }
 .CartIcon{
     display: flex;
     flex-grow: 0.1;
     align-items: center;
+    justify-content: center;
     text-decoration: none;
 }
 
@@ -40,10 +42,12 @@ header svg{
     margin: 0 auto;
 }
 
-a svg {
+a{
     color: inherit;
+    text-decoration: none;
 }
   
-a:visited svg {
+a:visited{
     color: inherit;
+    text-decoration: none;
 }

--- a/Frontend/Components/Navbar/Navbar.jsx
+++ b/Frontend/Components/Navbar/Navbar.jsx
@@ -3,13 +3,17 @@ import "./Navbar.css";
 function Navbar () {
   return (
     <header>
-      <a href="/" className="SiteNameHeader">
-        <h1> Site Name</h1>
-      </a>
+      <div className="SiteNameHeader">
+        <a href="/" >
+          <h1> Site Name</h1>
+        </a>
+      </div>
       {/*cart icon*/}
-      <a href="/cart" className="CartIcon">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="feather feather-shopping-cart"><circle cx="9" cy="21" r="1"></circle><circle cx="20" cy="21" r="1"></circle><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"></path></svg>
-      </a>
+      <div className="CartIcon">
+        <a href="/cart">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="feather feather-shopping-cart"><circle cx="9" cy="21" r="1"></circle><circle cx="20" cy="21" r="1"></circle><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"></path></svg>
+        </a>
+      </div>
     </header>
   );
 }

--- a/Frontend/pages/Productpage/Productpage.css
+++ b/Frontend/pages/Productpage/Productpage.css
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    width:100%;
 }
 
 .product-container {


### PR DESCRIPTION
- Wrapped both navbar items in divs to ensure `<a>` tag only had effect when clicking the item
- Modified class styling to ensure `<a>` tags were centered in divs
- Ensured product page was 100% width since removing the * CSS in main.css in the previous merge
- Made navbar width 100% instead of 100vw to remove set values